### PR TITLE
fix: update ToS and Privacy Policy links in auth forms to point to real pages

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -292,8 +292,8 @@ export function LoginForm({
         </CardContent>
       </Card>
       <FieldDescription className="px-6 text-center">
-        By clicking continue, you agree to our <a href="#">Terms of Service</a>{" "}
-        and <a href="#">Privacy Policy</a>.
+        By clicking continue, you agree to our <a href="/terms">Terms of Service</a>{", "}
+        and <a href="/privacy">Privacy Policy</a>.
       </FieldDescription>
     </div>
   )

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -365,8 +365,8 @@ export function SignupForm({
         </CardContent>
       </Card>
       <FieldDescription className="px-6 text-center">
-        By clicking continue, you agree to our <a href="#">Terms of Service</a>{" "}
-        and <a href="#">Privacy Policy</a>.
+        By clicking continue, you agree to our <a href="/terms">Terms of Service</a>{", "}
+        and <a href="/privacy">Privacy Policy</a>.
       </FieldDescription>
     </div>
   )


### PR DESCRIPTION
Closes #5

The Terms of Service and Privacy Policy links in login and signup forms were pointing to '#'. Updated them to point to the actual /terms and /privacy pages.