### PR TITLE
feat: replace hardcoded dashboard data with real Prisma queries

### DIFF
--- a/app/(protected)/(admin)/dashboard/actions.ts
+++ b/app/(protected)/(admin)/dashboard/actions.ts
@@ -1,0 +1,38 @@
+"use server"
+
+import { prisma } from "@/lib/prisma"
+
+export async function getDashboardStats() {
+  const [
+    totalUsers,
+    activeSubscriptions,
+    totalRevenue,
+    recentUsers,
+  ] = await Promise.all([
+    prisma.user.count(),
+    prisma.subscription.count({
+      where: { status: "active" },
+    }),
+    prisma.payment.aggregate({
+      _sum: { amount: true },
+      where: { status: "succeeded" },
+    }),
+    prisma.user.findMany({
+      take: 5,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        createdAt: true,
+      },
+    }),
+  ])
+
+  return {
+    totalUsers,
+    activeSubscriptions,
+    totalRevenue: totalRevenue._sum.amount ?? 0,
+    recentUsers,
+  }
+}

--- a/app/(protected)/(admin)/dashboard/page.tsx
+++ b/app/(protected)/(admin)/dashboard/page.tsx
@@ -1,15 +1,18 @@
 import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 import { DataTable } from "@/components/data-table"
 import { SectionCards } from "@/components/section-cards"
+import { getDashboardStats } from "./actions"
 
 import data from "./data.json"
 
 export default async function Page() {
+  const stats = await getDashboardStats()
+
   return (
     <div className="flex flex-1 flex-col">
       <div className="@container/main flex flex-1 flex-col gap-2">
         <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
-          <SectionCards />
+          <SectionCards stats={stats} />
           <div className="px-4 lg:px-6">
             <ChartAreaInteractive />
           </div>

--- a/components/section-cards.tsx
+++ b/components/section-cards.tsx
@@ -10,91 +10,127 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 
-export function SectionCards() {
+interface SectionCardsProps {
+  stats?: {
+    totalUsers: number
+    activeSubscriptions: number
+    totalRevenue: number
+  }
+}
+
+export function SectionCards({ stats }: SectionCardsProps) {
+  // Payment amounts are stored in cents — convert to dollars
+  const totalRevenueDollars = ((stats?.totalRevenue ?? 0) / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+  const totalUsers = stats?.totalUsers ?? 0
+  const activeSubscriptions = stats?.activeSubscriptions ?? 0
+  const conversionRate =
+    totalUsers > 0
+      ? ((activeSubscriptions / totalUsers) * 100).toFixed(1)
+      : null
+
   return (
     <div className="*:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card dark:*:data-[slot=card]:bg-card grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-gradient-to-t *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
       <Card className="@container/card">
         <CardHeader>
           <CardDescription>Total Revenue</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            $1,250.00
+            ${totalRevenueDollars}
           </CardTitle>
           <CardAction>
             <Badge variant="outline">
               <IconTrendingUp />
-              +12.5%
+              Live
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
-            Trending up this month <IconTrendingUp className="size-4" />
+            Succeeded payments <IconTrendingUp className="size-4" />
           </div>
           <div className="text-muted-foreground">
-            Visitors for the last 6 months
+            Aggregated from all payment records
           </div>
         </CardFooter>
       </Card>
+
       <Card className="@container/card">
         <CardHeader>
-          <CardDescription>New Customers</CardDescription>
+          <CardDescription>Total Users</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            1,234
+            {totalUsers.toLocaleString()}
           </CardTitle>
           <CardAction>
             <Badge variant="outline">
-              <IconTrendingDown />
-              -20%
+              <IconTrendingUp />
+              Live
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
-            Down 20% this period <IconTrendingDown className="size-4" />
+            Registered accounts <IconTrendingUp className="size-4" />
           </div>
           <div className="text-muted-foreground">
-            Acquisition needs attention
+            All-time user count
           </div>
         </CardFooter>
       </Card>
+
       <Card className="@container/card">
         <CardHeader>
-          <CardDescription>Active Accounts</CardDescription>
+          <CardDescription>Active Subscriptions</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            45,678
+            {activeSubscriptions.toLocaleString()}
           </CardTitle>
           <CardAction>
             <Badge variant="outline">
               <IconTrendingUp />
-              +12.5%
+              Live
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
-            Strong user retention <IconTrendingUp className="size-4" />
+            Active paying subscribers <IconTrendingUp className="size-4" />
           </div>
-          <div className="text-muted-foreground">Engagement exceed targets</div>
+          <div className="text-muted-foreground">
+            Current active subscriptions
+          </div>
         </CardFooter>
       </Card>
+
       <Card className="@container/card">
         <CardHeader>
-          <CardDescription>Growth Rate</CardDescription>
+          <CardDescription>Conversion Rate</CardDescription>
           <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-            4.5%
+            {conversionRate !== null ? `${conversionRate}%` : "N/A"}
           </CardTitle>
           <CardAction>
             <Badge variant="outline">
-              <IconTrendingUp />
-              +4.5%
+              {conversionRate !== null && parseFloat(conversionRate) >= 5 ? (
+                <>
+                  <IconTrendingUp />
+                  Healthy
+                </>
+              ) : (
+                <>
+                  <IconTrendingDown />
+                  Watch
+                </>
+              )}
             </Badge>
           </CardAction>
         </CardHeader>
         <CardFooter className="flex-col items-start gap-1.5 text-sm">
           <div className="line-clamp-1 flex gap-2 font-medium">
-            Steady performance increase <IconTrendingUp className="size-4" />
+            Active subs / total users <IconTrendingUp className="size-4" />
           </div>
-          <div className="text-muted-foreground">Meets growth projections</div>
+          <div className="text-muted-foreground">
+            Subscription conversion rate
+          </div>
         </CardFooter>
       </Card>
     </div>


### PR DESCRIPTION
Closes #21

Replaces the hardcoded data in the dashboard with real Prisma queries:

### Changes

**`app/(protected)/(admin)/dashboard/actions.ts`** _(new)_
- `getDashboardStats()` server action using `Promise.all` to fetch in parallel:
  - `totalUsers` — `prisma.user.count()`
  - `activeSubscriptions` — `prisma.subscription.count({ where: { status: "active" } })`
  - `totalRevenue` — `prisma.payment.aggregate({ _sum: { amount } })` on succeeded payments
  - `recentUsers` — last 5 registered users (used for future components)

**`components/section-cards.tsx`** _(updated)_
- Accepts a `stats` prop (`SectionCardsProps`) instead of hardcoded numbers
- Falls back to `0` / `"N/A"` when stats are not yet available
- Revenue displayed in dollars (amounts stored as cents in DB)
- Fourth card now shows the subscription **conversion rate** (active subs / total users)

**`app/(protected)/(admin)/dashboard/page.tsx`** _(updated)_
- Calls `getDashboardStats()` and passes result to `<SectionCards stats={stats} />`
- `data.json` is kept for the `<DataTable>` component