### PR TITLE
feat: implement contact form backend with email notifications

### DIFF
--- a/actions/contact/submit-contact.ts
+++ b/actions/contact/submit-contact.ts
@@ -1,7 +1,8 @@
 'use server';
 
 import { z } from 'zod';
-import { db } from '@/lib/db';
+import { prisma } from '@/lib/prisma';
+import { headers } from 'next/headers';
 import nodemailer from 'nodemailer';
 import { getContactFormTemplate } from '@/lib/email-templates/contact-form-template';
 import { appConfig } from '@/lib/config';
@@ -26,33 +27,62 @@ export async function submitContact(
 
   const { fullName, email, phoneNumber, message } = parsed.data;
 
+  // Capture the submitter's IP for spam / audit purposes
+  const headersList = await headers();
+  const ipAddress =
+    headersList.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    headersList.get('x-real-ip') ||
+    null;
+
   try {
-    const adminEmailSetting = await db.setting.findUnique({ where: { key: 'email' } });
-    const toEmail = adminEmailSetting?.value || process.env.SMTP_FROM_EMAIL;
-
-    if (!toEmail) {
-      return { error: 'Contact email is not configured. Please try again later.' };
-    }
-
-    const transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: parseInt(process.env.SMTP_PORT || '587'),
-      secure: process.env.SMTP_SECURE === 'true',
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASSWORD,
+    // Persist the submission before attempting to send email
+    await prisma.contactSubmission.create({
+      data: {
+        fullName,
+        email,
+        phoneNumber: phoneNumber ?? null,
+        message,
+        ipAddress,
       },
     });
 
-    const htmlContent = getContactFormTemplate({ fullName, email, phoneNumber, message });
+    // Send email notification to admin (non-blocking — failure returns success
+    // so the user isn't penalised for a transient SMTP error)
+    try {
+      const adminEmailSetting = await prisma.setting.findUnique({
+        where: { key: 'email' },
+      });
+      const toEmail = adminEmailSetting?.value || process.env.SMTP_FROM_EMAIL;
 
-    await transporter.sendMail({
-      from: process.env.SMTP_FROM_EMAIL,
-      to: toEmail,
-      replyTo: email,
-      subject: `New Contact Form Inquiry from ${fullName} — ${appConfig.name}`,
-      html: htmlContent,
-    });
+      if (toEmail) {
+        const transporter = nodemailer.createTransport({
+          host: process.env.SMTP_HOST,
+          port: parseInt(process.env.SMTP_PORT || '587'),
+          secure: process.env.SMTP_SECURE === 'true',
+          auth: {
+            user: process.env.SMTP_USER,
+            pass: process.env.SMTP_PASSWORD,
+          },
+        });
+
+        const htmlContent = getContactFormTemplate({
+          fullName,
+          email,
+          phoneNumber,
+          message,
+        });
+
+        await transporter.sendMail({
+          from: process.env.SMTP_FROM_EMAIL,
+          to: toEmail,
+          replyTo: email,
+          subject: `New Contact Form Inquiry from ${fullName} — ${appConfig.name}`,
+          html: htmlContent,
+        });
+      }
+    } catch (emailError) {
+      console.error('Failed to send contact notification email:', emailError);
+    }
 
     return { success: true };
   } catch (error) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -215,3 +215,18 @@ model Blog {
   @@index([published])
   @@index([slug])
 }
+
+// Stores contact form submissions for admin review and audit trail
+model ContactSubmission {
+  id          String   @id @default(cuid())
+  fullName    String
+  email       String
+  phoneNumber String?
+  message     String
+  ipAddress   String?
+  status      String   @default("new") // new, read, replied
+  createdAt   DateTime @default(now())
+
+  @@index([status])
+  @@index([createdAt])
+}


### PR DESCRIPTION
Closes #27

Implements a fully persistent contact form backend that matches the existing `ContactForm` client component.

### Changes

**`prisma/schema.prisma`** _(updated)_

Added `ContactSubmission` model:
```prisma
model ContactSubmission {
  id          String   @id @default(cuid())
  fullName    String
  email       String
  phoneNumber String?
  message     String
  ipAddress   String?
  status      String   @default("new") // new, read, replied
  createdAt   DateTime @default(now())

  @@index([status])
  @@index([createdAt])
}
```
Fields match the existing form (`fullName`, `phoneNumber` instead of `name`/`subject`).

**`actions/contact/submit-contact.ts`** _(updated)_

- **Fixed import**: replaced `@/lib/db` (didn't exist) with `@/lib/prisma`
- **DB persistence**: `prisma.contactSubmission.create()` is called _before_ sending email — the submission is always saved even if the SMTP server is down
- **IP capture**: reads `x-forwarded-for` / `x-real-ip` from Next.js `headers()` and stores it on the submission
- **Email resilience**: SMTP errors are caught and logged but do not fail the response — the user always gets a success if their data was saved
- Existing nodemailer + `getContactFormTemplate` email logic is preserved

### Migration required

After merging, run:
```bash
npx prisma migrate dev --name add_contact_submission
```