### PR TITLE
feat: add OAuth social login (Google and GitHub)

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -22,6 +22,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { z } from "zod"
+import { SocialLoginButtons } from "@/components/social-login-buttons"
 
 const loginSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -50,7 +51,6 @@ export function LoginForm({
     const emailValue = formData.get("email") as string
     const password = formData.get("password") as string
 
-    // Validate with Zod
     const validation = loginSchema.safeParse({ email: emailValue, password })
 
     if (!validation.success) {
@@ -72,10 +72,8 @@ export function LoginForm({
       })
 
       if (error) {
-        // Check if error is due to unverified email
         if (error.message?.toLowerCase().includes("email not verified") || 
             error.message?.toLowerCase().includes("verify")) {
-          // Send OTP and show verification screen
           setEmail(emailValue)
           await handleSendOtp(emailValue)
           setShowOtpVerification(true)
@@ -287,12 +285,15 @@ export function LoginForm({
                   Don&apos;t have an account? <a href="/signup">Sign up</a>
                 </FieldDescription>
               </Field>
+              <SocialLoginButtons mode="login" />
             </FieldGroup>
           </form>
         </CardContent>
       </Card>
       <FieldDescription className="px-6 text-center">
-        By clicking continue, you agree to our <a href="#">Terms of Service</a>{" "}
+        By clicking continue, you agree to our <a href="#">Terms of Service</a>{
+          " "
+        }
         and <a href="#">Privacy Policy</a>.
       </FieldDescription>
     </div>

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -23,12 +23,12 @@ import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { z } from "zod"
 import { isValidPhoneNumber, type Value } from "react-phone-number-input"
+import { SocialLoginButtons } from "@/components/social-login-buttons"
 
 const signupSchema = z.object({
   name: z.string().min(2, "Name must be at least 2 characters"),
   email: z.string().email("Please enter a valid email address"),
   phone: z.union([z.string(), z.undefined()]).optional().refine((val) => {
-    // Phone is optional - empty or valid
     if (!val || val.length === 0) return true;
     try {
       return isValidPhoneNumber(val);
@@ -69,7 +69,6 @@ export function SignupForm({
     const password = formData.get("password") as string
     const confirmPassword = formData.get("confirm-password") as string
 
-    // Validate with Zod
     const validation = signupSchema.safeParse({ 
       name, 
       email: emailValue, 
@@ -101,7 +100,6 @@ export function SignupForm({
         name,
       };
       
-      // Add phone if provided
       if (phone) {
         signupData.phone = phone;
       }
@@ -114,7 +112,6 @@ export function SignupForm({
         return
       }
 
-      // Show OTP verification form
       setEmail(emailValue)
       setShowOtpVerification(true)
       toast.success("Account created! Please check your email for the verification code.")
@@ -360,12 +357,15 @@ export function SignupForm({
                   Already have an account? <a href="/login">Sign in</a>
                 </FieldDescription>
               </Field>
+              <SocialLoginButtons mode="signup" />
             </FieldGroup>
           </form>
         </CardContent>
       </Card>
       <FieldDescription className="px-6 text-center">
-        By clicking continue, you agree to our <a href="#">Terms of Service</a>{" "}
+        By clicking continue, you agree to our <a href="#">Terms of Service</a>{
+          " "
+        }
         and <a href="#">Privacy Policy</a>.
       </FieldDescription>
     </div>

--- a/components/social-login-buttons.tsx
+++ b/components/social-login-buttons.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { authClient } from "@/lib/auth-client"
+import { toast } from "sonner"
+
+interface SocialLoginButtonsProps {
+  mode?: "login" | "signup"
+}
+
+const GoogleIcon = () => (
+  <svg className="h-4 w-4 mr-2" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+  </svg>
+)
+
+const GitHubIcon = () => (
+  <svg className="h-4 w-4 mr-2" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+  </svg>
+)
+
+export function SocialLoginButtons({ mode = "login" }: SocialLoginButtonsProps) {
+  const [loadingProvider, setLoadingProvider] = useState<string | null>(null)
+
+  const handleSocialLogin = async (provider: "google" | "github") => {
+    setLoadingProvider(provider)
+    try {
+      await authClient.signIn.social({
+        provider,
+        callbackURL: "/dashboard",
+        errorCallbackURL: "/login?error=social-login-failed",
+      })
+    } catch (error) {
+      toast.error(`Failed to ${mode === "login" ? "sign in" : "sign up"} with ${provider}`)
+      setLoadingProvider(null)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">Or continue with</span>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={!!loadingProvider}
+          onClick={() => handleSocialLogin("google")}
+          aria-label="Continue with Google"
+        >
+          {loadingProvider === "google" ? (
+            <span className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          ) : (
+            <GoogleIcon />
+          )}
+          Google
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={!!loadingProvider}
+          onClick={() => handleSocialLogin("github")}
+          aria-label="Continue with GitHub"
+        >
+          {loadingProvider === "github" ? (
+            <span className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          ) : (
+            <GitHubIcon />
+          )}
+          GitHub
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -41,6 +41,24 @@ export const auth = betterAuth({
     sendOnSignUp: true,
     autoSignInAfterVerification: false,
   },
+  socialProviders: {
+    ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+      ? {
+          google: {
+            clientId: process.env.GOOGLE_CLIENT_ID,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+          },
+        }
+      : {}),
+    ...(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET
+      ? {
+          github: {
+            clientId: process.env.GITHUB_CLIENT_ID,
+            clientSecret: process.env.GITHUB_CLIENT_SECRET,
+          },
+        }
+      : {}),
+  },
   user: {
     additionalFields: {
       phone: {


### PR DESCRIPTION
Closes #18

Adds Google and GitHub OAuth providers using better-auth.

⚠️ **Requires configuration** — see issue #18 comment for setup instructions.

Changes:
- Updated lib/auth.ts to include social providers
- Added social login buttons to login and signup forms
- Environment variables needed: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET