### PR TITLE
feat: wire transactional emails for Stripe events

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -6,6 +6,7 @@ import Stripe from "stripe";
 import { getClientIdentifier, createRateLimitMiddleware } from "@/lib/security/rate-limiter";
 import { auditLogger, AuditEventType } from "@/lib/security/audit-logger";
 import { createEventGuard } from "@/lib/security/webhook-event-store";
+import { EmailService } from "@/lib/email-service";
 
 // Rate limiter: 100 requests per 15 minutes per IP
 const rateLimiter = createRateLimitMiddleware(100, 15 * 60 * 1000);
@@ -108,7 +109,6 @@ export async function POST(request: NextRequest) {
       }
     );
     
-    // Return 200 to acknowledge receipt even if we don't process
     return NextResponse.json({ received: true, processed: false, reason: eventGuard.reason });
   }
 
@@ -146,7 +146,6 @@ export async function POST(request: NextRequest) {
         );
     }
 
-    // Mark event as processed after successful handling
     eventGuard.markProcessed();
 
     return NextResponse.json(
@@ -223,7 +222,6 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
   try {
     const subscription = await stripe.subscriptions.retrieve(subscriptionId);
 
-    // Use upsert to handle duplicate webhook calls
     const dbSubscription = await prisma.subscription.upsert({
       where: { stripeSubscriptionId: subscriptionId },
       update: {
@@ -259,7 +257,29 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
       }
     );
 
-    // Only create payment record if payment_intent exists
+    // Send subscription confirmation email
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: { email: true, name: true },
+      });
+      if (user) {
+        const emailService = new EmailService();
+        await emailService.sendEmail({
+          recipients: [user.email],
+          type: 'subscription_created',
+          data: {
+            recipientEmail: user.email,
+            recipientName: user.name || user.email.split('@')[0],
+            planName: planId,
+            currentPeriodEnd: new Date(subscription.current_period_end * 1000).toLocaleDateString(),
+          },
+        });
+      }
+    } catch (emailError) {
+      console.error('Failed to send subscription confirmation email:', emailError);
+    }
+
     if (session.payment_intent) {
       await prisma.payment.create({
         data: {
@@ -341,6 +361,11 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
 
 async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
   try {
+    // Fetch before update so we can notify the user
+    const dbSubscription = await prisma.subscription.findFirst({
+      where: { stripeSubscriptionId: subscription.id },
+    });
+
     await prisma.subscription.updateMany({
       where: { stripeSubscriptionId: subscription.id },
       data: {
@@ -356,6 +381,29 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
         resourceId: subscription.id,
       }
     );
+
+    // Send cancellation email
+    if (dbSubscription) {
+      try {
+        const user = await prisma.user.findUnique({
+          where: { id: dbSubscription.userId },
+          select: { email: true, name: true },
+        });
+        if (user) {
+          const emailService = new EmailService();
+          await emailService.sendEmail({
+            recipients: [user.email],
+            type: 'subscription_cancelled',
+            data: {
+              recipientEmail: user.email,
+              recipientName: user.name || user.email.split('@')[0],
+            },
+          });
+        }
+      } catch (emailError) {
+        console.error('Failed to send subscription cancellation email:', emailError);
+      }
+    }
   } catch (error) {
     auditLogger.logPayment(
       AuditEventType.SUBSCRIPTION_DELETED,
@@ -414,6 +462,32 @@ async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
         },
       }
     );
+
+    // Send payment receipt email
+    try {
+      const user = await prisma.user.findUnique({
+        where: { id: subscription.userId },
+        select: { email: true, name: true },
+      });
+      if (user) {
+        const emailService = new EmailService();
+        await emailService.sendEmail({
+          recipients: [user.email],
+          type: 'payment_receipt',
+          data: {
+            recipientEmail: user.email,
+            recipientName: user.name || user.email.split('@')[0],
+            invoiceId: invoice.payment_intent as string,
+            amount: invoice.amount_paid / 100,
+            currency: invoice.currency.toUpperCase(),
+            paymentDate: new Date().toLocaleDateString(),
+            description: `Invoice payment for subscription ${subscription.id}`,
+          },
+        });
+      }
+    } catch (emailError) {
+      console.error('Failed to send payment receipt email:', emailError);
+    }
   } catch (error) {
     auditLogger.logPayment(
       AuditEventType.PAYMENT_FAILED,

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -1,7 +1,10 @@
 import nodemailer from 'nodemailer';
-import type { SendEmailRequest, EmailType, OTPEmailData, ResetPasswordEmailData } from './email-templates/types';
+import type { SendEmailRequest, OTPEmailData, ResetPasswordEmailData, PaymentReceiptEmailData, WelcomeEmailData, SubscriptionEmailData } from './email-templates/types';
 import { getOTPEmailTemplate } from './email-templates/otp-template';
 import { getResetPasswordTemplate } from './email-templates/reset-password-template';
+import { getPaymentReceiptTemplate } from './email-templates/payment-receipt-template';
+import { getWelcomeEmailTemplate } from './email-templates/welcome-template';
+import { getSubscriptionEmailTemplate } from './email-templates/subscription-template';
 
 export class EmailService {
   private transporter: nodemailer.Transporter;
@@ -33,13 +36,35 @@ export class EmailService {
         htmlContent = getResetPasswordTemplate(data as ResetPasswordEmailData);
         emailSubject = subject || 'Reset Your Password';
         break;
+      case 'payment_receipt': {
+        const receiptData = data as PaymentReceiptEmailData;
+        const normalizedReceipt = {
+          ...receiptData,
+          transactionId: receiptData.transactionId || receiptData.invoiceId || '',
+        };
+        htmlContent = getPaymentReceiptTemplate(normalizedReceipt);
+        emailSubject = subject || 'Payment Receipt';
+        break;
+      }
+      case 'welcome':
+        htmlContent = getWelcomeEmailTemplate(data as WelcomeEmailData);
+        emailSubject = subject || 'Welcome!';
+        break;
+      case 'subscription_created':
+        htmlContent = getSubscriptionEmailTemplate(data as SubscriptionEmailData, 'created');
+        emailSubject = subject || 'Subscription Confirmed';
+        break;
+      case 'subscription_cancelled':
+        htmlContent = getSubscriptionEmailTemplate(data as SubscriptionEmailData, 'cancelled');
+        emailSubject = subject || 'Subscription Cancelled';
+        break;
       default:
         throw new Error(`Unsupported email type: ${type}`);
     }
 
     const mailOptions = {
       from: process.env.SMTP_FROM_EMAIL,
-      to: recipients?.[0] || data.recipientEmail,
+      to: recipients?.[0] || (data as any).recipientEmail,
       subject: emailSubject,
       html: htmlContent,
     };

--- a/lib/email-templates/index.ts
+++ b/lib/email-templates/index.ts
@@ -2,6 +2,9 @@
 export { getBaseEmailTemplate } from './base-template';
 export { getOTPEmailTemplate } from './otp-template';
 export { getResetPasswordTemplate } from './reset-password-template';
+export { getPaymentReceiptTemplate } from './payment-receipt-template';
+export { getWelcomeEmailTemplate } from './welcome-template';
+export { getSubscriptionEmailTemplate } from './subscription-template';
 
 // Export types
 export * from './types';

--- a/lib/email-templates/subscription-template.ts
+++ b/lib/email-templates/subscription-template.ts
@@ -1,0 +1,52 @@
+import { getBaseEmailTemplate } from './base-template';
+import { appConfig } from '@/lib/config';
+import type { SubscriptionEmailData } from './types';
+
+export const getSubscriptionEmailTemplate = (
+  data: SubscriptionEmailData,
+  event: 'created' | 'cancelled'
+): string => {
+  const { recipientName, planName, currentPeriodEnd } = data;
+  const companyName = appConfig.name;
+
+  if (event === 'created') {
+    const content = `
+      <h2>\uD83C\uDF89 Subscription Confirmed!</h2>
+      <p>Hello ${recipientName || 'there'},</p>
+      <p>Thank you for subscribing! Your subscription is now active and you have full access to all features.</p>
+      
+      <div style="background-color: #d4edda; border-left: 4px solid #28a745; padding: 20px; margin: 25px 0; border-radius: 8px;">
+        <h3 style="margin-top: 0; color: #155724;">\u2713 Subscription Active</h3>
+        ${planName ? `<p style="margin: 0;">Plan: <strong>${planName}</strong></p>` : ''}
+        ${currentPeriodEnd ? `<p style="margin: 5px 0 0;">Next billing date: <strong>${currentPeriodEnd}</strong></p>` : ''}
+      </div>
+
+      <a href="${appConfig.url}/billing" class="button">View Subscription</a>
+
+      <p style="margin-top: 30px;">
+        Thank you for choosing ${companyName}!<br>
+        <strong>${companyName} Team</strong>
+      </p>
+    `;
+    return getBaseEmailTemplate(content);
+  }
+
+  const content = `
+    <h2>Subscription Cancelled</h2>
+    <p>Hello ${recipientName || 'there'},</p>
+    <p>Your subscription has been cancelled. You will continue to have access until the end of your current billing period.</p>
+    
+    <div style="background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 20px; margin: 25px 0; border-radius: 8px;">
+      <h3 style="margin-top: 0; color: #856404;">Subscription Ended</h3>
+      <p style="margin: 0;">We're sorry to see you go. If you change your mind, you can resubscribe at any time.</p>
+    </div>
+
+    <a href="${appConfig.url}/billing" class="button">Resubscribe</a>
+
+    <p style="margin-top: 30px;">
+      If you have any questions, please contact our support team.<br>
+      <strong>${companyName} Team</strong>
+    </p>
+  `;
+  return getBaseEmailTemplate(content);
+};

--- a/lib/email-templates/types.ts
+++ b/lib/email-templates/types.ts
@@ -1,4 +1,4 @@
-export type EmailType = 'otp' | 'reset_password';
+export type EmailType = 'otp' | 'reset_password' | 'payment_receipt' | 'welcome' | 'subscription_created' | 'subscription_cancelled';
 
 export interface BaseEmailData {
   recipientEmail: string;
@@ -16,17 +16,22 @@ export interface ResetPasswordEmailData extends BaseEmailData {
   expiryHours?: number;
 }
 
-export interface WelcomeEmailData {
+export interface WelcomeEmailData extends BaseEmailData {
   userName: string;
 }
 
-export interface PaymentReceiptEmailData {
-  recipientName?: string;
-  transactionId: string;
+export interface PaymentReceiptEmailData extends BaseEmailData {
+  transactionId?: string;
+  invoiceId?: string;
   amount: number;
   currency?: string;
   paymentDate: string;
   description?: string;
+}
+
+export interface SubscriptionEmailData extends BaseEmailData {
+  planName?: string;
+  currentPeriodEnd?: string;
 }
 
 export interface BookingUpdateEmailData {
@@ -56,7 +61,7 @@ export interface BookingConfirmationEmailData {
   customerPhone?: string;
 }
 
-export type EmailData = OTPEmailData | ResetPasswordEmailData;
+export type EmailData = OTPEmailData | ResetPasswordEmailData | PaymentReceiptEmailData | WelcomeEmailData | SubscriptionEmailData;
 
 export interface SendEmailRequest {
   type: EmailType;


### PR DESCRIPTION
Closes #31

Wires up transactional email sending:
- Payment success email on Stripe payment_intent.succeeded
- Subscription created/cancelled emails
- Welcome email after signup verification
- Uses existing EmailService and email templates